### PR TITLE
Use absolute paths in PATH/LD_LIBRARY_PATH

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -19,5 +19,5 @@ curl -L --silent $DOWNLOAD_URL | tar xz
 echo "exporting PATH and LIBRARY_PATH" | indent
 PROFILE_PATH="$BUILD_DIR/.profile.d/ffmpeg.sh"
 mkdir -p $(dirname $PROFILE_PATH)
-echo 'export PATH="$PATH:vendor/ffmpeg/bin"' >> $PROFILE_PATH
-echo 'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:vendor/ffmpeg/lib"' >> $PROFILE_PATH
+echo 'export PATH="$PATH:$HOME/vendor/ffmpeg/bin"' >> $PROFILE_PATH
+echo 'export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOME/vendor/ffmpeg/lib"' >> $PROFILE_PATH


### PR DESCRIPTION
Otherwise, it's only executable from `/app`:

```
$ heroku run bash
Running `bash` attached to terminal... up, run.8774
~ $ which ffmpeg
vendor/ffmpeg/bin/ffmpeg
~ $ echo $PATH
/usr/local/bin:/usr/bin:/bin:vendor/ffmpeg/bin
~ $ mkdir foo
~ $ cd foo
~/foo $ ffmpeg
bash: ffmpeg: command not found
```
