### PR TITLE
Update ffmpeg to version 2.5

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -7,7 +7,7 @@ indent() {
 echo "-----> Install ffmpeg"
 BUILD_DIR=$1
 VENDOR_DIR="vendor"
-DOWNLOAD_URL="https://github.com/lukasz-madon/heroku-binaries/blob/master/ffmpeg.tar.gz"
+DOWNLOAD_URL="https://lukasz-madon.github.io/heroku-binaries/libs/ffmpeg.tar.gz"
 
 echo "DOWNLOAD_URL = " $DOWNLOAD_URL | indent
 

--- a/bin/compile
+++ b/bin/compile
@@ -7,7 +7,7 @@ indent() {
 echo "-----> Install ffmpeg"
 BUILD_DIR=$1
 VENDOR_DIR="vendor"
-DOWNLOAD_URL="http://flect.github.io/heroku-binaries/libs/ffmpeg.tar.gz"
+DOWNLOAD_URL="https://github.com/lukasz-madon/heroku-binaries/blob/master/ffmpeg.tar.gz"
 
 echo "DOWNLOAD_URL = " $DOWNLOAD_URL | indent
 

--- a/bin/compile
+++ b/bin/compile
@@ -7,7 +7,7 @@ indent() {
 echo "-----> Install ffmpeg"
 BUILD_DIR=$1
 VENDOR_DIR="vendor"
-DOWNLOAD_URL="https://lukasz-madon.github.io/heroku-binaries/libs/ffmpeg.tar.gz"
+DOWNLOAD_URL="https://ffmpeg.org/releases/ffmpeg-2.5.tar.gz"
 
 echo "DOWNLOAD_URL = " $DOWNLOAD_URL | indent
 


### PR DESCRIPTION
Current ffmpeg version is out of date. Also, buildpack fetches binary from official website.

_It's possible that this PR will break if someone depends on lower version_ 
